### PR TITLE
Fix pre-release version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-NAME    := mercury
-SRC_EXT := gz
+NAME       := mercury
+SRC_EXT    := gz
+DL_VERSION := 2.0.0a1
 
 SLES_15_REPOS = $(OPENSUSE_REPOS_MIRROR)/repositories/science:/HPC/openSUSE_Leap_15.1/
 

--- a/mercury.spec
+++ b/mercury.spec
@@ -8,24 +8,25 @@
 %global shortmchecksum_commit %%(c=%%{mchecksum_commit}; echo ${c:0:7})
 
 %bcond_with use_release
+%global dl_version 2.0.0a1
 
 Name: mercury
-Version: 2.0.0a1
-Release: 0.8.git.%{shortmercury_commit}%{?dist}
+Version: 2.0.0~a1
+Release: 1.git.%{shortmercury_commit}%{?dist}
 
 Summary:	Mercury
 
 Group:		Development/Libraries
 License:	ANL
 URL:		http://mercury-hpc.github.io/documentation/
-Source0:	https://github.com/mercury-hpc/%{name}/archive/v%{version}.tar.gz
+Source0:	https://github.com/mercury-hpc/%{name}/archive/v%{dl_version}.tar.gz
 Patch1:		https://github.com/mercury-hpc/mercury/compare/v2.0.0a1..%{mercury_commit}.patch
 Source1:	https://github.com/mercury-hpc/kwsys/archive/%{shortkwsys_commit}.tar.gz
 Source2:	https://github.com/mercury-hpc/preprocessor/archive/%{shortboost_commit}.tar.gz
 Source3:	https://github.com/mercury-hpc/mchecksum/archive/%{shortmchecksum_commit}.tar.gz
 
 BuildRequires:	openpa-devel
-BuildRequires:	libfabric-devel >= 1.5.0
+BuildRequires:	libfabric-devel >= 1.9.0-5
 BuildRequires:	cmake
 BuildRequires:	boost-devel
 BuildRequires:	gcc-c++
@@ -51,6 +52,7 @@ Mercury
 %package devel
 Summary:	Mercury devel package
 Requires:	%{name}%{?_isa} = %{version}-%{release}
+Requires:	libfabric-devel >= 1.9.0-5
 
 %description devel
 Mercury devel
@@ -59,7 +61,7 @@ Mercury devel
 %if %{with use_release}
 %autosetup -p1
 %else
-%setup -q
+%setup -q -n mercury-%dl_version
 %patch1 -p1
 rmdir Testing/driver/kwsys/
 tar -C Testing/driver/ -xzf %{SOURCE1}
@@ -118,6 +120,10 @@ cd build
 
 
 %changelog
+* Thu May 07 2020 Brian J. Murrell <brian.murrell@intel> - 2.0.0~a1-1
+- Fix pre-release tag in Version:
+- Add Requires: libfabric-devel to devel package
+
 * Thu Apr 9 2020 Alexander A Oganezov <alexander.a.oganezov@intel.com> - 2.0.0a1-0.8
 - Update to 4871023058887444d47ead4d089c99db979f3d93
 

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -14,6 +14,7 @@ DISTRO_BASE = $(basename UBUNTU_$(VERSION_ID))
 VERSION_ID_STR := $(subst $(DOT),_,$(VERSION_ID))
 endif
 ifeq ($(ID),fedora)
+SPECTOOL    := spectool
 # a Fedora-based mock builder
 # derive the the values of:
 # VERSION_ID (i.e. 7)
@@ -25,6 +26,13 @@ DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 VERSION_ID  := 7
 DISTRO_ID   := el7
 DISTRO_BASE := EL_7
+SED_EXPR    := 1s/$(DIST)//p
+endif
+ifeq ($(CHROOT_NAME),epel-8-x86_64)
+DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
+VERSION_ID  := 8
+DISTRO_ID   := el8
+DISTRO_BASE := EL_8
 SED_EXPR    := 1s/$(DIST)//p
 endif
 ifeq ($(CHROOT_NAME),opensuse-leap-15.1-x86_64)
@@ -45,6 +53,7 @@ DISTRO_ID := el$(VERSION_ID)
 DISTRO_BASE := $(basename EL_$(VERSION_ID))
 DIST        := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 SED_EXPR    := 1s/$(DIST)//p
+SPECTOOL    := spectool
 define install_repo
 	if yum-config-manager --add-repo=$(1); then                  \
 	    repo_file=$$(ls -tar /etc/yum.repos.d/*.repo | tail -1); \
@@ -66,6 +75,7 @@ DISTRO_ID := sle$(VERSION_ID)
 DISTRO_BASE := $(basename SLES_$(VERSION_ID))
 endif
 ifeq ($(ID_LIKE),suse)
+SPECTOOL    := rpmdev-spectool
 define install_repo
 	zypper --non-interactive ar $(1)
 endef

--- a/packaging/Makefile_packaging.mk
+++ b/packaging/Makefile_packaging.mk
@@ -24,6 +24,7 @@ BUILD_OS ?= leap.15
 PACKAGING_CHECK_DIR ?= ../packaging
 LOCAL_REPOS ?= true
 
+PR_REPOS         := $(shell set -x; git show -s --format=%B | sed -ne 's/^PR-repos: *\(.*\)/\1/p')
 COMMON_RPM_ARGS  := --define "%_topdir $$PWD/_topdir" $(BUILD_DEFINES)
 SPEC             := $(shell if [ -f $(NAME)-$(DISTRO_BASE).spec ]; then echo $(NAME)-$(DISTRO_BASE).spec; else echo $(NAME).spec; fi)
 VERSION           = $(eval VERSION := $(shell rpm $(COMMON_RPM_ARGS) --specfile --qf '%{version}\n' $(SPEC) | sed -n '1p'))$(VERSION)
@@ -36,8 +37,8 @@ RPMS              = $(eval RPMS := $(addsuffix .rpm,$(addprefix _topdir/RPMS/x86
 DEB_TOP          := _topdir/BUILD
 DEB_BUILD        := $(DEB_TOP)/$(NAME)-$(DEB_VERS)
 DEB_TARBASE      := $(DEB_TOP)/$(DEB_NAME)_$(DEB_VERS)
-SOURCE            = $(eval SOURCE := $(shell CHROOT_NAME=$(CHROOT_NAME) spectool -S -l $(SPEC) | sed -e 2,\$$d -e 's/.*:  *//'))$(SOURCE)
-PATCHES           = $(eval PATCHES := $(shell CHROOT_NAME=$(CHROOT_NAME) spectool -l $(SPEC) | sed -e 1d -e 's/.*:  *//' -e 's/.*\///'))$(PATCHES)
+SOURCE           ?= $(eval SOURCE := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) -S -l $(SPEC) | sed -e 2,\$$d -e 's/.*:  *//'))$(SOURCE)
+PATCHES          ?= $(eval PATCHES := $(shell CHROOT_NAME=$(CHROOT_NAME) $(SPECTOOL) -l $(SPEC) | sed -e 1d -e 's/.*:  *//' -e 's/.*\///'))$(PATCHES)
 SOURCES          := $(addprefix _topdir/SOURCES/,$(notdir $(SOURCE)) $(PATCHES))
 ifeq ($(ID_LIKE),debian)
 DEBS             := $(addsuffix _$(DEB_VERS)-1_amd64.deb,$(shell sed -n '/-udeb/b; s,^Package:[[:blank:]],$(DEB_TOP)/,p' debian/control))
@@ -338,10 +339,10 @@ gpgcheck=False\n" >> /etc/mock/$(CHROOT_NAME).cfg;                              
 	    else                                                                            \
 	        LOCAL_REPOS="$($(DISTRO_BASE)_LOCAL_REPOS)";                                \
 	    fi;                                                                             \
-	    for repo in $$LOCAL_REPOS $($(DISTRO_BASE)_REPOS); do                           \
+	    for repo in $(JOB_REPOS) $$LOCAL_REPOS $($(DISTRO_BASE)_REPOS); do              \
 	        repo_name=$${repo##*://};                                                   \
 	        repo_name=$${repo_name//\//_};                                              \
-	        echo -e "[$$repo_name]\n\
+	        echo -e "[$${repo_name//@/_}]\n\
 name=$${repo_name}\n\
 baseurl=$${repo}\n\
 enabled=1\n" >> /etc/mock/$(CHROOT_NAME).cfg;                                               \


### PR DESCRIPTION
RPM delineates pre-release tags in it's versions with a `~`.  Using this specification,
RPM understands that 2.0.0 > 2.0.0~*.  Version comparison also works within the
tag so that `2.0.0~b2` > `2.0.0~b1` > `2.0.0~a1`

The current version of our mercury RPM however, `2.0.0a1` does not compare properly
as `2.0.0a1` > `2.0.0`, which will become a supportability issue for us when mercury
does finally release their 2.0.0 GA.

This patch fixes that supportability problem as well as updating our minimum acceptable
version of libfabric to our latest build.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>