### PR TITLE
DAOS-11467 mercury: Add local address to end point for single IB device.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mercury (2.2.0-3) unstable; urgency=medium
+  [ Joseph Moore ]
+  * Fix defect in connect function.
+
+ -- Joseph Moore <joseph.moore@intel.com>  Tue Sep 20 2022 10:11:20 -0500
+
 mercury (2.2.0-2) unstable; urgency=medium
   [ Joseph Moore ]
   * Add ucx patch to include local address in ep for single IB device.

--- a/mercury.spec
+++ b/mercury.spec
@@ -1,6 +1,6 @@
 Name: mercury
 Version: 2.2.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 # dl_version is version with ~ removed
 %{lua:
@@ -187,6 +187,9 @@ rm -rf $RPM_BUILD_ROOT/.variants
 %{_datadir}/cmake/
 
 %changelog
+* Tue Sep 20 2022 Joseph Moore <joseph.moore@intel.com> - 2.2.0-3
+- Fix defect in connect function.
+
 * Fri Sep 09 2022 Joseph Moore <joseph.moore@intel.com> - 2.2.0-2
 - Add na_ucx.c patch to change ep creation for single IB device.
 

--- a/na_ucx_local_addr.patch
+++ b/na_ucx_local_addr.patch
@@ -103,7 +103,7 @@ index db4fc75..20a9af2 100644
          .sockaddr = (ucs_sock_addr_t){.addr = addr, .addrlen = addrlen},
          .conn_request = NULL};
  
-+    if (addr) {
++    if (local_addr) {
 +    	ep_params.field_mask |= UCP_EP_PARAM_FIELD_LOCAL_SOCK_ADDR;
 +        ep_params.local_sockaddr.addr = (const struct sockaddr*) local_addr;
 +        ep_params.local_sockaddr.addrlen = sizeof(*local_addr);


### PR DESCRIPTION


Fixes bug in na_ucp_connect function.

Signed-off-by: Joseph Moore <joseph.moore@intel.com>