### PR TITLE
DAOS-14418 mercury: Update na_ucx.c to retry am_send for out-of-memory.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+
+mercury (2.3.1~rc1-2) unstable; urgency=medium
+  [ Joseph Moore ]
+  * Add patch to na_ucx.c to force retry of out-of-memory error
+
+ -- Joseph Moore <joseph.moore@intel.com>  Tue, 26 Sep 2023 07:04:02 -0500
+
 mercury (2.3.1~rc1-1) unstable; urgency=medium
   [ Jerome Soumagne ]
   * Update to 2.3.1rc1

--- a/mercury.spec
+++ b/mercury.spec
@@ -1,6 +1,6 @@
 Name: mercury
 Version: 2.3.1~rc1
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 # dl_version is version with ~ removed
 %{lua:

--- a/mercury.spec
+++ b/mercury.spec
@@ -28,6 +28,7 @@ License:  BSD
 Group:    Development/Libraries
 URL:      http://mercury-hpc.github.io/
 Source0:  https://github.com/mercury-hpc/%{name}/releases/download/v%{dl_version}/%{name}-%{dl_version}.tar.bz2
+Patch0:   na_ucx_am_send_retry.patch
 
 BuildRequires:  libfabric-devel >= 1.14.0
 BuildRequires:  cmake
@@ -145,6 +146,9 @@ Mercury plugin to support the UCX transport.
 %{_libdir}/cmake/
 
 %changelog
+* Tue Sep 26 2023 Joseph Moore <joseph.moore@intel.com> - 2.3.1~rc1-2
+- Add patch to na_ucx.c to force retry of out-of-memory error.
+
 * Tue Aug 29 2023 Jerome Soumagne <jerome.soumagne@intel.com> - 2.3.1~rc1-1
 - Update to 2.3.1rc1
 

--- a/na_ucx_am_send_retry.patch
+++ b/na_ucx_am_send_retry.patch
@@ -1,0 +1,180 @@
+diff --git a/src/na/na_ucx.c b/src/na/na_ucx.c
+index b14bd91..73d0dcf 100644
+--- a/src/na/na_ucx.c
++++ b/src/na/na_ucx.c
+@@ -26,6 +26,9 @@
+ 
+ #include <netdb.h>
+ #include <sys/socket.h>
++#include <sys/types.h>
++#include <unistd.h>
++#include <ctype.h>
+ 
+ /****************/
+ /* Local Macros */
+@@ -37,6 +40,9 @@
+ /* Default protocol */
+ #define NA_UCX_PROTOCOL_DEFAULT "all"
+ 
++/* Remap for send "out of memory" failure */
++#define NA_UCX_REMAP_SEND_NOMEM (0)
++
+ /* Default features
+  * (AM for unexpected messages and TAG for expected messages) */
+ #define NA_UCX_FEATURES (UCP_FEATURE_AM | UCP_FEATURE_TAG | UCP_FEATURE_RMA)
+@@ -256,6 +262,7 @@ struct na_ucx_class {
+     size_t expected_size_max;      /* Max expected size */
+     hg_atomic_int32_t ncontexts;   /* Number of contexts */
+     bool no_wait;                  /* Wait disabled */
++    bool remap_send_nomem;         /* remap send nomem to timeout */
+ };
+ 
+ /* Datatype used for printing info */
+@@ -446,14 +453,14 @@ na_ucp_mem_buf_deregister(void *handle, void *arg);
+  */
+ static na_return_t
+ na_ucp_am_send(ucp_ep_h ep, const void *buf, size_t buf_size,
+-    const ucp_tag_t *tag, void *request);
++    const ucp_tag_t *tag, void *request, struct na_ucx_class *na_ucx_class);
+ 
+ /**
+  * Send active message callback.
+  */
+ static void
+ na_ucp_am_send_cb(
+-    void *request, ucs_status_t status, void NA_UNUSED *user_data);
++    void *request, ucs_status_t status, void *user_data);
+ 
+ /**
+  * Check if we received an AM or push the op to OP queue.
+@@ -693,6 +700,12 @@ na_ucx_complete(struct na_ucx_op_id *na_ucx_op_id, na_return_t cb_ret);
+ static NA_INLINE void
+ na_ucx_release(void *arg);
+ 
++/**
++ * Configure class parameters from environment variables.
++ */
++static na_return_t
++na_ucx_class_env_config(struct na_ucx_class * na_ucx_class);
++
+ /********************/
+ /* Plugin callbacks */
+ /********************/
+@@ -1771,14 +1784,15 @@ na_ucp_ep_close(ucp_ep_h ep)
+ /*---------------------------------------------------------------------------*/
+ static na_return_t
+ na_ucp_am_send(ucp_ep_h ep, const void *buf, size_t buf_size,
+-    const ucp_tag_t *tag, void *request)
++    const ucp_tag_t *tag, void *request, struct na_ucx_class *na_ucx_class)
+ {
+     const ucp_request_param_t send_params = {
+         .op_attr_mask = UCP_OP_ATTR_FIELD_REQUEST | UCP_OP_ATTR_FIELD_CALLBACK |
+-                        UCP_OP_ATTR_FIELD_FLAGS,
++                        UCP_OP_ATTR_FIELD_FLAGS | UCP_OP_ATTR_FIELD_USER_DATA,
+         .cb = {.send = na_ucp_am_send_cb},
+         .flags = UCP_AM_SEND_FLAG_REPLY,
+-        .request = request};
++        .request = request,
++        .user_data = na_ucx_class};
+     ucs_status_ptr_t status_ptr;
+     na_return_t ret;
+ 
+@@ -1809,9 +1823,10 @@ error:
+ 
+ /*---------------------------------------------------------------------------*/
+ static void
+-na_ucp_am_send_cb(void *request, ucs_status_t status, void NA_UNUSED *user_data)
++na_ucp_am_send_cb(void *request, ucs_status_t status, void *user_data)
+ {
+     na_return_t cb_ret;
++    struct na_ucx_class * na_ucx_class = (struct na_ucx_class *) user_data;
+ 
+     NA_LOG_SUBSYS_DEBUG(
+         msg, "ucp_am_send_nbx() completed (%s)", ucs_status_string(status));
+@@ -1820,9 +1835,13 @@ na_ucp_am_send_cb(void *request, ucs_status_t status, void NA_UNUSED *user_data)
+         NA_GOTO_DONE(done, cb_ret, NA_SUCCESS);
+     if (status == UCS_ERR_CANCELED)
+         NA_GOTO_DONE(done, cb_ret, NA_CANCELED);
++    else if (status == UCS_ERR_NO_MEMORY && na_ucx_class->remap_send_nomem)
++        NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, NA_TIMEOUT,
++            "ucp_am_send_nbx() failed (NA_NOMEM mapped to NA_TIMEOUT)");
+     else
+         NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, na_ucs_status_to_na(status),
+-            "ucp_am_send_nbx() failed (%s)", ucs_status_string(status));
++            "ucp_am_send_nbx() failed (%s), status: (%d)",
++            ucs_status_string(status), status);
+ 
+ done:
+     na_ucx_complete((struct na_ucx_op_id *) request, cb_ret);
+@@ -2022,6 +2041,9 @@ na_ucp_msg_send_cb(
+         NA_GOTO_DONE(done, cb_ret, NA_SUCCESS);
+     if (status == UCS_ERR_CANCELED)
+         NA_GOTO_DONE(done, cb_ret, NA_CANCELED);
++    else if (status = UCS_ERR_NO_MEMORY)
++        NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, NA_TIMEOUT,
++            "ucp_am_send_nbx() failed (NA_NOMEM mapped to NA_TIMEOUT)");
+     else
+         NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, na_ucs_status_to_na(status),
+             "ucp_tag_send_nbx() failed (%s)", ucs_status_string(status));
+@@ -2945,6 +2967,24 @@ na_ucx_release(void *arg)
+     }
+ }
+ 
++/*---------------------------------------------------------------------------*/
++static na_return_t
++na_ucx_class_env_config(struct na_ucx_class * na_ucx_class)
++{
++    char *env;
++    na_return_t ret;
++
++    /* Set unexpected msg callbacks */
++    env = getenv("NA_UCX_REMAP_SEND_NOMEM");
++    if (env == NULL || env[0] == '0' || tolower(env[0]) == 'n' ||
++        tolower(env[0]) == 'f') {
++        na_ucx_class->remap_send_nomem = false;
++    } else {
++        NA_LOG_SUBSYS_DEBUG(cls, "NA_UCX_REMAP_SEND_NOMEM set");
++        na_ucx_class->remap_send_nomem = true;
++    }
++
++}
+ /********************/
+ /* Plugin callbacks */
+ /********************/
+@@ -3106,6 +3146,12 @@ na_ucx_initialize(
+     NA_CHECK_SUBSYS_ERROR(cls, na_ucx_class == NULL, error, ret, NA_NOMEM,
+         "Could not allocate NA UCX class");
+ 
++
++    /* Check env config */
++    ret = na_ucx_class_env_config(na_ucx_class);
++    NA_CHECK_SUBSYS_NA_ERROR(
++        cls, error, ret, "na_ucx_class_env_config() failed");
++
+     /* Keep a copy of the protocol name */
+     na_ucx_class->protocol_name = (na_info->protocol_name)
+                                       ? strdup(na_info->protocol_name)
+@@ -3593,9 +3639,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
+ 
+ /*---------------------------------------------------------------------------*/
+ static na_return_t
+-na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
+-    na_context_t *context, na_cb_t callback, void *arg, const void *buf,
+-    size_t buf_size, void NA_UNUSED *plugin_data, na_addr_t *dest_addr,
++na_ucx_msg_send_unexpected(na_class_t *na_class, na_context_t *context,
++    na_cb_t callback, void *arg, const void *buf, size_t buf_size,
++    void NA_UNUSED *plugin_data, na_addr_t *dest_addr,
+     uint8_t NA_UNUSED dest_id, na_tag_t tag, na_op_id_t *op_id)
+ {
+     struct na_ucx_addr *na_ucx_addr = (struct na_ucx_addr *) dest_addr;
+@@ -3630,7 +3676,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
+         .buf.const_ptr = buf, .buf_size = buf_size, .tag = (ucp_tag_t) tag};
+ 
+     ret = na_ucp_am_send(na_ucx_addr->ucp_ep, buf, buf_size,
+-        &na_ucx_op_id->info.msg.tag, na_ucx_op_id);
++        &na_ucx_op_id->info.msg.tag, na_ucx_op_id,
++	NA_UCX_CLASS(na_class));
++
+     NA_CHECK_SUBSYS_NA_ERROR(msg, release, ret, "Could not post msg send");
+ 
+     return NA_SUCCESS;

--- a/na_ucx_am_send_retry.patch
+++ b/na_ucx_am_send_retry.patch
@@ -1,5 +1,5 @@
 diff --git a/src/na/na_ucx.c b/src/na/na_ucx.c
-index b14bd91..73d0dcf 100644
+index b14bd91..2dec406 100644
 --- a/src/na/na_ucx.c
 +++ b/src/na/na_ucx.c
 @@ -26,6 +26,9 @@
@@ -12,17 +12,7 @@ index b14bd91..73d0dcf 100644
  
  /****************/
  /* Local Macros */
-@@ -37,6 +40,9 @@
- /* Default protocol */
- #define NA_UCX_PROTOCOL_DEFAULT "all"
- 
-+/* Remap for send "out of memory" failure */
-+#define NA_UCX_REMAP_SEND_NOMEM (0)
-+
- /* Default features
-  * (AM for unexpected messages and TAG for expected messages) */
- #define NA_UCX_FEATURES (UCP_FEATURE_AM | UCP_FEATURE_TAG | UCP_FEATURE_RMA)
-@@ -256,6 +262,7 @@ struct na_ucx_class {
+@@ -256,6 +259,7 @@ struct na_ucx_class {
      size_t expected_size_max;      /* Max expected size */
      hg_atomic_int32_t ncontexts;   /* Number of contexts */
      bool no_wait;                  /* Wait disabled */
@@ -30,7 +20,7 @@ index b14bd91..73d0dcf 100644
  };
  
  /* Datatype used for printing info */
-@@ -446,14 +453,14 @@ na_ucp_mem_buf_deregister(void *handle, void *arg);
+@@ -446,14 +450,14 @@ na_ucp_mem_buf_deregister(void *handle, void *arg);
   */
  static na_return_t
  na_ucp_am_send(ucp_ep_h ep, const void *buf, size_t buf_size,
@@ -47,7 +37,7 @@ index b14bd91..73d0dcf 100644
  
  /**
   * Check if we received an AM or push the op to OP queue.
-@@ -693,6 +700,12 @@ na_ucx_complete(struct na_ucx_op_id *na_ucx_op_id, na_return_t cb_ret);
+@@ -693,6 +697,12 @@ na_ucx_complete(struct na_ucx_op_id *na_ucx_op_id, na_return_t cb_ret);
  static NA_INLINE void
  na_ucx_release(void *arg);
  
@@ -60,7 +50,7 @@ index b14bd91..73d0dcf 100644
  /********************/
  /* Plugin callbacks */
  /********************/
-@@ -1771,14 +1784,15 @@ na_ucp_ep_close(ucp_ep_h ep)
+@@ -1771,14 +1781,15 @@ na_ucp_ep_close(ucp_ep_h ep)
  /*---------------------------------------------------------------------------*/
  static na_return_t
  na_ucp_am_send(ucp_ep_h ep, const void *buf, size_t buf_size,
@@ -79,7 +69,7 @@ index b14bd91..73d0dcf 100644
      ucs_status_ptr_t status_ptr;
      na_return_t ret;
  
-@@ -1809,9 +1823,10 @@ error:
+@@ -1809,9 +1820,10 @@ error:
  
  /*---------------------------------------------------------------------------*/
  static void
@@ -91,7 +81,7 @@ index b14bd91..73d0dcf 100644
  
      NA_LOG_SUBSYS_DEBUG(
          msg, "ucp_am_send_nbx() completed (%s)", ucs_status_string(status));
-@@ -1820,9 +1835,13 @@ na_ucp_am_send_cb(void *request, ucs_status_t status, void NA_UNUSED *user_data)
+@@ -1820,9 +1832,13 @@ na_ucp_am_send_cb(void *request, ucs_status_t status, void NA_UNUSED *user_data)
          NA_GOTO_DONE(done, cb_ret, NA_SUCCESS);
      if (status == UCS_ERR_CANCELED)
          NA_GOTO_DONE(done, cb_ret, NA_CANCELED);
@@ -106,7 +96,7 @@ index b14bd91..73d0dcf 100644
  
  done:
      na_ucx_complete((struct na_ucx_op_id *) request, cb_ret);
-@@ -2022,6 +2041,9 @@ na_ucp_msg_send_cb(
+@@ -2022,6 +2038,9 @@ na_ucp_msg_send_cb(
          NA_GOTO_DONE(done, cb_ret, NA_SUCCESS);
      if (status == UCS_ERR_CANCELED)
          NA_GOTO_DONE(done, cb_ret, NA_CANCELED);
@@ -116,7 +106,7 @@ index b14bd91..73d0dcf 100644
      else
          NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, na_ucs_status_to_na(status),
              "ucp_tag_send_nbx() failed (%s)", ucs_status_string(status));
-@@ -2945,6 +2967,24 @@ na_ucx_release(void *arg)
+@@ -2945,6 +2964,24 @@ na_ucx_release(void *arg)
      }
  }
  
@@ -129,19 +119,19 @@ index b14bd91..73d0dcf 100644
 +
 +    /* Set unexpected msg callbacks */
 +    env = getenv("NA_UCX_REMAP_SEND_NOMEM");
-+    if (env == NULL || env[0] == '0' || tolower(env[0]) == 'n' ||
-+        tolower(env[0]) == 'f') {
-+        na_ucx_class->remap_send_nomem = false;
++    if (env != NULL && (env[0] == '1' || tolower(env[0]) == 'y' ||
++        tolower(env[0]) == 't')) {
++        na_ucx_class->remap_send_nomem = true;
 +    } else {
 +        NA_LOG_SUBSYS_DEBUG(cls, "NA_UCX_REMAP_SEND_NOMEM set");
-+        na_ucx_class->remap_send_nomem = true;
++        na_ucx_class->remap_send_nomem = false;
 +    }
 +
 +}
  /********************/
  /* Plugin callbacks */
  /********************/
-@@ -3106,6 +3146,12 @@ na_ucx_initialize(
+@@ -3106,6 +3143,12 @@ na_ucx_initialize(
      NA_CHECK_SUBSYS_ERROR(cls, na_ucx_class == NULL, error, ret, NA_NOMEM,
          "Could not allocate NA UCX class");
  
@@ -154,7 +144,7 @@ index b14bd91..73d0dcf 100644
      /* Keep a copy of the protocol name */
      na_ucx_class->protocol_name = (na_info->protocol_name)
                                        ? strdup(na_info->protocol_name)
-@@ -3593,9 +3639,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
+@@ -3593,9 +3636,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
  
  /*---------------------------------------------------------------------------*/
  static na_return_t
@@ -167,7 +157,7 @@ index b14bd91..73d0dcf 100644
      uint8_t NA_UNUSED dest_id, na_tag_t tag, na_op_id_t *op_id)
  {
      struct na_ucx_addr *na_ucx_addr = (struct na_ucx_addr *) dest_addr;
-@@ -3630,7 +3676,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
+@@ -3630,7 +3673,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
          .buf.const_ptr = buf, .buf_size = buf_size, .tag = (ucp_tag_t) tag};
  
      ret = na_ucp_am_send(na_ucx_addr->ucp_ep, buf, buf_size,

--- a/na_ucx_am_send_retry.patch
+++ b/na_ucx_am_send_retry.patch
@@ -1,5 +1,5 @@
 diff --git a/src/na/na_ucx.c b/src/na/na_ucx.c
-index b14bd91..2dec406 100644
+index b14bd91..4c1ddb0 100644
 --- a/src/na/na_ucx.c
 +++ b/src/na/na_ucx.c
 @@ -26,6 +26,9 @@
@@ -106,7 +106,7 @@ index b14bd91..2dec406 100644
      else
          NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, na_ucs_status_to_na(status),
              "ucp_tag_send_nbx() failed (%s)", ucs_status_string(status));
-@@ -2945,6 +2964,24 @@ na_ucx_release(void *arg)
+@@ -2945,6 +2964,25 @@ na_ucx_release(void *arg)
      }
  }
  
@@ -128,10 +128,11 @@ index b14bd91..2dec406 100644
 +    }
 +
 +}
++
  /********************/
  /* Plugin callbacks */
  /********************/
-@@ -3106,6 +3143,12 @@ na_ucx_initialize(
+@@ -3106,6 +3144,12 @@ na_ucx_initialize(
      NA_CHECK_SUBSYS_ERROR(cls, na_ucx_class == NULL, error, ret, NA_NOMEM,
          "Could not allocate NA UCX class");
  
@@ -144,7 +145,7 @@ index b14bd91..2dec406 100644
      /* Keep a copy of the protocol name */
      na_ucx_class->protocol_name = (na_info->protocol_name)
                                        ? strdup(na_info->protocol_name)
-@@ -3593,9 +3636,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
+@@ -3593,9 +3637,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
  
  /*---------------------------------------------------------------------------*/
  static na_return_t
@@ -157,7 +158,7 @@ index b14bd91..2dec406 100644
      uint8_t NA_UNUSED dest_id, na_tag_t tag, na_op_id_t *op_id)
  {
      struct na_ucx_addr *na_ucx_addr = (struct na_ucx_addr *) dest_addr;
-@@ -3630,7 +3673,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
+@@ -3630,7 +3674,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
          .buf.const_ptr = buf, .buf_size = buf_size, .tag = (ucp_tag_t) tag};
  
      ret = na_ucp_am_send(na_ucx_addr->ucp_ep, buf, buf_size,

--- a/na_ucx_am_send_retry.patch
+++ b/na_ucx_am_send_retry.patch
@@ -1,5 +1,5 @@
 diff --git a/src/na/na_ucx.c b/src/na/na_ucx.c
-index b14bd91..4c1ddb0 100644
+index b14bd91..d02f39f 100644
 --- a/src/na/na_ucx.c
 +++ b/src/na/na_ucx.c
 @@ -26,6 +26,9 @@
@@ -119,8 +119,8 @@ index b14bd91..4c1ddb0 100644
 +
 +    /* Set unexpected msg callbacks */
 +    env = getenv("NA_UCX_REMAP_SEND_NOMEM");
-+    if (env != NULL && (env[0] == '1' || tolower(env[0]) == 'y' ||
-+        tolower(env[0]) == 't')) {
++    if (env == NULL || env[0] == '1' || tolower(env[0]) == 'y' ||
++        tolower(env[0]) == 't') {
 +        na_ucx_class->remap_send_nomem = true;
 +    } else {
 +        NA_LOG_SUBSYS_DEBUG(cls, "NA_UCX_REMAP_SEND_NOMEM set");

--- a/na_ucx_am_send_retry.patch
+++ b/na_ucx_am_send_retry.patch
@@ -1,5 +1,5 @@
 diff --git a/src/na/na_ucx.c b/src/na/na_ucx.c
-index b14bd91..d02f39f 100644
+index b14bd91..3c53dce 100644
 --- a/src/na/na_ucx.c
 +++ b/src/na/na_ucx.c
 @@ -26,6 +26,9 @@
@@ -96,17 +96,7 @@ index b14bd91..d02f39f 100644
  
  done:
      na_ucx_complete((struct na_ucx_op_id *) request, cb_ret);
-@@ -2022,6 +2038,9 @@ na_ucp_msg_send_cb(
-         NA_GOTO_DONE(done, cb_ret, NA_SUCCESS);
-     if (status == UCS_ERR_CANCELED)
-         NA_GOTO_DONE(done, cb_ret, NA_CANCELED);
-+    else if (status = UCS_ERR_NO_MEMORY)
-+        NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, NA_TIMEOUT,
-+            "ucp_am_send_nbx() failed (NA_NOMEM mapped to NA_TIMEOUT)");
-     else
-         NA_GOTO_SUBSYS_ERROR(msg, done, cb_ret, na_ucs_status_to_na(status),
-             "ucp_tag_send_nbx() failed (%s)", ucs_status_string(status));
-@@ -2945,6 +2964,25 @@ na_ucx_release(void *arg)
+@@ -2945,6 +2961,25 @@ na_ucx_release(void *arg)
      }
  }
  
@@ -122,17 +112,17 @@ index b14bd91..d02f39f 100644
 +    if (env == NULL || env[0] == '1' || tolower(env[0]) == 'y' ||
 +        tolower(env[0]) == 't') {
 +        na_ucx_class->remap_send_nomem = true;
-+    } else {
 +        NA_LOG_SUBSYS_DEBUG(cls, "NA_UCX_REMAP_SEND_NOMEM set");
++    } else {
 +        na_ucx_class->remap_send_nomem = false;
 +    }
-+
++    return NA_SUCCESS;
 +}
 +
  /********************/
  /* Plugin callbacks */
  /********************/
-@@ -3106,6 +3144,12 @@ na_ucx_initialize(
+@@ -3106,6 +3141,12 @@ na_ucx_initialize(
      NA_CHECK_SUBSYS_ERROR(cls, na_ucx_class == NULL, error, ret, NA_NOMEM,
          "Could not allocate NA UCX class");
  
@@ -145,7 +135,7 @@ index b14bd91..d02f39f 100644
      /* Keep a copy of the protocol name */
      na_ucx_class->protocol_name = (na_info->protocol_name)
                                        ? strdup(na_info->protocol_name)
-@@ -3593,9 +3637,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
+@@ -3593,9 +3634,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
  
  /*---------------------------------------------------------------------------*/
  static na_return_t
@@ -158,7 +148,7 @@ index b14bd91..d02f39f 100644
      uint8_t NA_UNUSED dest_id, na_tag_t tag, na_op_id_t *op_id)
  {
      struct na_ucx_addr *na_ucx_addr = (struct na_ucx_addr *) dest_addr;
-@@ -3630,7 +3674,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
+@@ -3630,7 +3671,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
          .buf.const_ptr = buf, .buf_size = buf_size, .tag = (ucp_tag_t) tag};
  
      ret = na_ucp_am_send(na_ucx_addr->ucp_ep, buf, buf_size,

--- a/na_ucx_am_send_retry.patch
+++ b/na_ucx_am_send_retry.patch
@@ -1,5 +1,5 @@
 diff --git a/src/na/na_ucx.c b/src/na/na_ucx.c
-index b14bd91..3c53dce 100644
+index b14bd91..942e938 100644
 --- a/src/na/na_ucx.c
 +++ b/src/na/na_ucx.c
 @@ -26,6 +26,9 @@
@@ -96,7 +96,7 @@ index b14bd91..3c53dce 100644
  
  done:
      na_ucx_complete((struct na_ucx_op_id *) request, cb_ret);
-@@ -2945,6 +2961,25 @@ na_ucx_release(void *arg)
+@@ -2945,6 +2961,24 @@ na_ucx_release(void *arg)
      }
  }
  
@@ -105,7 +105,6 @@ index b14bd91..3c53dce 100644
 +na_ucx_class_env_config(struct na_ucx_class * na_ucx_class)
 +{
 +    char *env;
-+    na_return_t ret;
 +
 +    /* Set unexpected msg callbacks */
 +    env = getenv("NA_UCX_REMAP_SEND_NOMEM");
@@ -122,7 +121,7 @@ index b14bd91..3c53dce 100644
  /********************/
  /* Plugin callbacks */
  /********************/
-@@ -3106,6 +3141,12 @@ na_ucx_initialize(
+@@ -3106,6 +3140,12 @@ na_ucx_initialize(
      NA_CHECK_SUBSYS_ERROR(cls, na_ucx_class == NULL, error, ret, NA_NOMEM,
          "Could not allocate NA UCX class");
  
@@ -135,7 +134,7 @@ index b14bd91..3c53dce 100644
      /* Keep a copy of the protocol name */
      na_ucx_class->protocol_name = (na_info->protocol_name)
                                        ? strdup(na_info->protocol_name)
-@@ -3593,9 +3634,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
+@@ -3593,9 +3633,9 @@ na_ucx_msg_buf_free(na_class_t *na_class, void *buf, void *plugin_data)
  
  /*---------------------------------------------------------------------------*/
  static na_return_t
@@ -148,7 +147,7 @@ index b14bd91..3c53dce 100644
      uint8_t NA_UNUSED dest_id, na_tag_t tag, na_op_id_t *op_id)
  {
      struct na_ucx_addr *na_ucx_addr = (struct na_ucx_addr *) dest_addr;
-@@ -3630,7 +3671,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
+@@ -3630,7 +3670,9 @@ na_ucx_msg_send_unexpected(na_class_t NA_UNUSED *na_class,
          .buf.const_ptr = buf, .buf_size = buf_size, .tag = (ucp_tag_t) tag};
  
      ret = na_ucp_am_send(na_ucx_addr->ucp_ep, buf, buf_size,


### PR DESCRIPTION
Adds environment variable to enable/disable change.

Maps out-of-memory to timeout, instead of NO_MEM, when capability is enable by the environment variable.