### PR TITLE
DAOS-16928 mercury: Enable debug RPMs for Leap sub-packages.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+
+mercury (2.4.0-2) unstable; urgency=medium
+  [ Joseph Moore ]
+  * Enable debug RPMs for Leap sub-packages.
+
+ -- Joseph Moore <joseph.moore@hpe.com>  Tue, 07 Jan 2025 11:00:00 -0600
+
 mercury (2.4.0-1) unstable; urgency=medium
   [ Jerome Soumagne ]
   * Update to 2.4.0

--- a/mercury.spec
+++ b/mercury.spec
@@ -66,7 +66,7 @@ Mercury plugin to support the UCX transport.
 
 %if 0%{?suse_version}
 %global __debug_package 1
-%global _debuginfo_subpackages 0
+%global _debuginfo_subpackages 1
 %debug_package
 %endif
 
@@ -131,6 +131,9 @@ Mercury plugin to support the UCX transport.
 %{_libdir}/cmake/
 
 %changelog
+* Tue Jan 07 2025 Joseph Moore <joseph.moore@hpe.com> - 2.4.0-2
+- Enable debug RPMs for Leap sub-packages.
+
 * Mon Nov 04 2024 Jerome Soumagne <jerome.soumagne@intel.com> - 2.4.0-1
 - Update to 2.4.0
 - Update required libfabric version (>= 1.20)

--- a/mercury.spec
+++ b/mercury.spec
@@ -1,6 +1,6 @@
 Name: mercury
 Version: 2.4.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 # --without ucx build switch
 %bcond_without ucx

--- a/packaging/Makefile_distro_vars.mk
+++ b/packaging/Makefile_distro_vars.mk
@@ -91,6 +91,14 @@ DISTRO_VERSION  ?= $(VERSION_ID)
 ORIG_TARGET_VER := 15.5
 SED_EXPR        := 1p
 endif
+ifeq ($(CHROOT_NAME),opensuse-leap-15.6-x86_64)
+VERSION_ID      := 15.6
+DISTRO_ID       := sl15.6
+DISTRO_BASE     := LEAP_15
+DISTRO_VERSION  ?= $(VERSION_ID)
+ORIG_TARGET_VER := 15.6
+SED_EXPR        := 1p
+endif
 endif
 ifeq ($(ID),centos)
 ID = el


### PR DESCRIPTION
This PR affects a one-line change in the mercury.spec file to enable debug RPMs for Leap sub-packages. This was requested for debug purposes at LRZ (see refererenced and related JIRA tickets).